### PR TITLE
Make the "showSourceInfo" flag configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ exports.enhance = function(options) {
 	var levelNumber = levels[level];
 	if (typeof levelNumber !== 'undefined') currentLevel = levelNumber;
 	
-	showSourceInfo = (currentLevel !== 0);
+	showSourceInfo = (options.showSourceInfo !== undefined) ? options.showSourceInfo : (currentLevel !== 0);
 
 	global.console.info = LogBuilder.createLogger("INFO");
 


### PR DESCRIPTION
Make the "showSourceInfo" flag configurable. When the flag is not passed on, fall back on the default behaviour (only when level !== 0).
In some cases, we run with "INFO" level on production, and want to be able to configure the showSourceInfo flag.